### PR TITLE
Refactored (join * *) into 2 separate rules

### DIFF
--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -23,5 +23,12 @@
 
 (rule $Action ($PathPattern $Value) (interactive.JsonFn Join) (floating 1))
 
+(when doublestar
+  (rule $DSPathPattern (anypath) (interactive.JsonFn AnyPath) (floating 1))
+  # use $DSValue instead of $Value to prevent too many duplicates
+  (rule $DSValue (anyvalue) (ConstantFn *) (floating 1))
+  (rule $Action ($DSPathPattern $DSValue) (interactive.JsonFn Join) (floating 1))
+)
+
 (rule $Action (new $FileName) (lambda v (: new (var v))) (anchored 1))
 (rule $FileName ($TOKEN) (interactive.JsonFn Template))

--- a/src/edu/stanford/nlp/sempre/Learner.java
+++ b/src/edu/stanford/nlp/sempre/Learner.java
@@ -148,7 +148,7 @@ public class Learner {
     params.update(counts);
     LogInfo.end_track();
   }
-  
+
   public void onlineLearnExampleByFormula(Example ex, List<Formula> formulas) {
     HashMap<String, Double> counts = new HashMap<>();
     for (Derivation deriv : ex.predDerivations)

--- a/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
@@ -50,7 +50,7 @@ public class JsonFn extends SemanticFn {
 
   public static Options opts = new Options();
   Formula arg1, arg2;
-  enum Mode {PathElement, JsonValue, ConstantValue, Template, Join};
+  enum Mode {PathElement, JsonValue, ConstantValue, AnyPath, Template, Join};
   Mode mode;
   DerivationStream stream;
 
@@ -70,6 +70,8 @@ public class JsonFn extends SemanticFn {
       return new JsonValueStream(ex, c);
     } else if (mode == Mode.ConstantValue) {
       return new ConstantValueStream(ex, c);
+    } else if (mode == Mode.AnyPath) {
+      return new AnyPathStream(ex, c);
     } else if (mode == Mode.Join) {
       return new JoinStream(ex, c);
     } else if (mode == Mode.Template) {
@@ -347,6 +349,30 @@ public class JsonFn extends SemanticFn {
       JsonValue value = values.get(index);
       index++;
       Formula formula = new ValueFormula<JsonValue>(value);
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(formula)
+          .createDerivation();
+    }
+  }
+
+  // Generate all possible paths
+  static class AnyPathStream extends MultipleDerivationStream {
+    List<NameValue> paths = new ArrayList<NameValue>();
+    int index = 0;
+    Callable callable;
+
+    public AnyPathStream(Example ex, Callable c) {
+      callable = c;
+      // TODO: Add all paths to paths
+    }
+
+    public Derivation createDerivation() {
+      if (index >= paths.size())
+        return null;
+      NameValue path = paths.get(index);
+      index++;
+      Formula formula = new ValueFormula<NameValue>(path);
       return new Derivation.Builder()
           .withCallable(callable)
           .formula(formula)

--- a/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
@@ -1,7 +1,9 @@
 package edu.stanford.nlp.sempre.interactive;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -50,7 +52,7 @@ public class JsonFn extends SemanticFn {
 
   public static Options opts = new Options();
   Formula arg1, arg2;
-  enum Mode {PathElement, JsonValue, ConstantValue, AnyPath, Template, Join};
+  enum Mode {PathElement, JsonValue, ConstantValue, AnyPath, AnyPathElement, Template, Join};
   Mode mode;
   DerivationStream stream;
 
@@ -72,6 +74,8 @@ public class JsonFn extends SemanticFn {
       return new ConstantValueStream(ex, c);
     } else if (mode == Mode.AnyPath) {
       return new AnyPathStream(ex, c);
+    } else if (mode == Mode.AnyPathElement) {
+      return new AnyPathElementStream(ex, c);
     } else if (mode == Mode.Join) {
       return new JoinStream(ex, c);
     } else if (mode == Mode.Template) {
@@ -175,6 +179,13 @@ public class JsonFn extends SemanticFn {
       } else {
         throw new RuntimeException("unsuppported path formula: " + pathFormula);
       }
+      List<List<String>> matchedPaths;
+      if (pathPattern.stream().allMatch(p -> p.startsWith("$."))) {
+        // pathPattern contains full paths
+        matchedPaths = pathPattern.stream().map(p -> Arrays.asList(p.replaceAll("^\\$\\.", "").split("\\."))).collect(Collectors.toList());
+      } else {
+        matchedPaths = VegaResources.allPathsMatcher.match(pathPattern);
+      }
 
       // all the different ways of getting values
       Function<List<String>, Iterator<JsonValue>> pathToValue;
@@ -183,7 +194,7 @@ public class JsonFn extends SemanticFn {
 
         if ("*".equals(Formulas.getString(valueFormula))) {
           // LogInfo.logs("JoinStream.anyvalue %s", v);
-          pathToValue = p -> VegaResources.getValues(p).iterator();
+          pathToValue = p -> new HashSet<>(VegaResources.getValues(p)).iterator();
         } else {
           pathToValue = p -> Iterators.singletonIterator((JsonValue)v);
         }
@@ -192,11 +203,9 @@ public class JsonFn extends SemanticFn {
       }
 
       if (opts.verbose > 0) {
-        List<List<String>> currentpaths = VegaResources.allPathsMatcher.match(pathPattern);
-        LogInfo.logs("JsonFn Path %s, size %s", currentpaths, currentpaths.size());
+        LogInfo.logs("JsonFn Path %s, size %s", matchedPaths, matchedPaths.size());
       }
-      iterator = new EnumeratePathsIterator(VegaResources.allPathsMatcher.match(pathPattern).iterator(),
-          pathToValue);
+      iterator = new EnumeratePathsIterator(matchedPaths.iterator(), pathToValue);
     }
 
     private boolean checkType(List<String> path, JsonValue value) {
@@ -285,7 +294,7 @@ public class JsonFn extends SemanticFn {
     }
   }
 
-  // takes a token and check if it can be a path
+  // takes a token and check if it can be a value
   static class JsonValueStream extends SingleDerivationStream {
     Callable callable;
     int currIndex = 0;
@@ -356,15 +365,51 @@ public class JsonFn extends SemanticFn {
     }
   }
 
-  // Generate all possible paths
+  // Generate all possible full paths
   static class AnyPathStream extends MultipleDerivationStream {
-    List<NameValue> paths = new ArrayList<NameValue>();
+    static List<NameValue> paths = null;
     int index = 0;
     Callable callable;
 
     public AnyPathStream(Example ex, Callable c) {
       callable = c;
-      // TODO: Add all paths to paths
+      if (paths == null) {
+        // Only initialize once
+        paths = new ArrayList<>();
+        for (List<String> path : VegaResources.allPathsMatcher.getPaths()) {
+          paths.add(new NameValue("$." + String.join(".", path)));
+        }
+      }
+    }
+
+    public Derivation createDerivation() {
+      if (index >= paths.size())
+        return null;
+      NameValue path = paths.get(index);
+      index++;
+      Formula formula = new ValueFormula<NameValue>(path);
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(formula)
+          .createDerivation();
+    }
+  }
+
+  // Generate all possible path elements
+  static class AnyPathElementStream extends MultipleDerivationStream {
+    static List<NameValue> paths = null;
+    int index = 0;
+    Callable callable;
+
+    public AnyPathElementStream(Example ex, Callable c) {
+      callable = c;
+      if (paths == null) {
+        // Only initialize once
+        paths = new ArrayList<>();
+        for (String key : VegaResources.allPathsMatcher.pathKeys()) {
+          paths.add(new NameValue(key));
+        }
+      }
     }
 
     public Derivation createDerivation() {

--- a/src/edu/stanford/nlp/sempre/interactive/VegaLitePathMatcher.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaLitePathMatcher.java
@@ -21,17 +21,17 @@ public class VegaLitePathMatcher {
     // load paths from file
     Stream<String> stream = Files.lines(Paths.get(filePath));
     paths = stream.map(line -> Arrays.asList(line.split("\t"))).collect(Collectors.toList());
-    buildIndex(paths);
+    buildIndex();
     stream.close();
   }
 
   public VegaLitePathMatcher(List<List<String>> paths) {
     this.paths = paths;
-    buildIndex(paths);
+    buildIndex();
   }
 
-  private void buildIndex(List<List<String>> paths) {
-    // TODO Auto-generated method stub
+  private void buildIndex() {
+    paths = paths.stream().filter(p -> !p.isEmpty()).collect(Collectors.toList());
     index = new HashMap<>();
     for (List<String> path : paths) {
       for (String key : path) {


### PR DESCRIPTION
**Usage:** add `+Grammar.tags doublestar` to the command line

The new semantic function `AnyPath` generates any full paths (e.g., `$.encoding.x.type`). The generated paths are pruned to beam size before joining with any value.