### PR TITLE
Grammar for initial plot generation (work in progress)

### DIFF
--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -52,7 +52,8 @@
   (rule $InitChannelDef ($InitChannel)
         (interactive.JsonInitFn CountChannel) (floating 1))
 
-  (rule $InitChannelDefs ($InitChannelDef) (IdentityFn) (floating 1))
+  (rule $InitChannelDefs ($InitChannelDef)
+        (lambda d (:s (var d))) (floating 1))
   (rule $InitChannelDefs ($InitChannelDefs $InitChannelDef)
         (interactive.JsonInitFn Combine) (floating 1))
 

--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -9,18 +9,18 @@
 (rule $Value ($Regular) (interactive.VegaFn Field))
 (rule $Value ($Regular) (interactive.VegaFn Color))
 
-(rule $PathPattern ($Regular) (SimpleLexiconFn (type PATH)) (anchored 1)) 
-(rule $PathToken ($Regular) (interactive.JsonFn PathElement)) 
+(rule $PathPattern ($Regular) (SimpleLexiconFn (type PATH)) (anchored 1))
+(rule $PathToken ($Regular) (interactive.JsonFn PathElement))
 
 (rule $PathPattern ($PathPattern $PathToken) (lambda p1 (lambda p2 (:s (var p1) (var p2)))))
-(rule $PathPattern ($PathToken) (IdentityFn)) 
+(rule $PathPattern ($PathToken) (IdentityFn))
 #generate candidates from lexicon
 
 # generate candidates from the paths, should be floating
 (rule $PathPattern (anypath) (ConstantFn *) (floating 1))
 (rule $Value (anyvalue) (ConstantFn *) (floating 1))
-(rule $Value (anyvalue) (interactive.JsonFn ConstantValue) (floating 1))
 
+# handles the other 3 cases except doublestar
 (rule $Action ($PathPattern $Value) (interactive.JsonFn Join) (floating 1))
 
 (when doublestar
@@ -29,6 +29,3 @@
   (rule $DSValue (anyvalue) (ConstantFn *) (floating 1))
   (rule $Action ($DSPathPattern $DSValue) (interactive.JsonFn Join) (floating 1))
 )
-
-(rule $Action (new $FileName) (lambda v (: new (var v))) (anchored 1))
-(rule $FileName ($TOKEN) (interactive.JsonFn Template))

--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -20,6 +20,9 @@
 (rule $PathPattern (anypath) (ConstantFn *) (floating 1))
 (rule $Value (anyvalue) (ConstantFn *) (floating 1))
 
+# this seems worse than using getValue from VegaResources
+#(rule $Value (anyvalue) (interactive.JsonFn ConstantValue) (floating 1))
+
 # handles the other 3 cases except doublestar
 (rule $Action ($PathPattern $Value) (interactive.JsonFn Join) (floating 1))
 

--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -32,3 +32,13 @@
 
 (rule $Action (new $FileName) (lambda v (: new (var v))) (anchored 1))
 (rule $FileName ($TOKEN) (interactive.JsonFn Template))
+
+################################
+# Initial Plot Generation
+# Inspired by Voyager 2 suggestion algorithm
+
+(when init-plot
+
+
+
+)

--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -56,7 +56,7 @@
   (rule $InitMark ($Regular) (interactive.VegaFn Mark))
   (rule $InitMark (anyvalue) (interactive.JsonInitFn AnyMark) (floating 1))
 
-  (rule $ROOT ($InitMark $InitConcreteChannelDefs)
+  (rule $ROOT ($InitMark $InitChannelDefs)
         (interactive.JsonInitFn Finalize) (floating 1))
 
 )

--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -47,9 +47,9 @@
 
   (rule $InitChannelDef ($InitChannel $InitField)
         (interactive.JsonInitFn NormalChannel) (floating 1))
-  (rule $InitChannelDef ($InitField)
+  (rule $InitChannelDef ($InitChannel $InitField)
         (interactive.JsonInitFn AggregateChannel) (floating 1))
-  (rule $InitChannelDef (anyvalue)
+  (rule $InitChannelDef ($InitChannel)
         (interactive.JsonInitFn CountChannel) (floating 1))
 
   (rule $InitChannelDefs ($InitChannelDef) (IdentityFn) (floating 1))

--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -39,27 +39,24 @@
 (when init-plot
 
   (rule $InitChannel ($Regular) (interactive.VegaFn Channel))
-  (rule $InitChannel (anyvalue) (ConstantFn *) (floating 1))
+  (rule $InitChannel (anyvalue) (interactive.JsonInitFn AnyChannel) (floating 1))
+
   (rule $InitField ($Regular) (interactive.VegaFn Field))
+  (rule $InitField (anyvalue) (interactive.JsonInitFn AnyField) (floating 1))
   (rule $InitField (anyvalue) (ConstantFn *) (floating 1))
+
+  (rule $InitChannelDef ($InitChannel $InitField)
+        (interactive.JsonInitFn ChannelDef) (floating 1))
+
+  (rule $InitChannelDefs ($InitChannelDef)
+        (interactive.JsonInitFn CombineDefs) (floating 1))
+  (rule $InitChannelDefs ($InitChannelDefs $InitChannelDef)
+        (interactive.JsonInitFn CombineDefs) (floating 1))
+
   (rule $InitMark ($Regular) (interactive.VegaFn Mark))
   (rule $InitMark (anyvalue) (interactive.JsonInitFn AnyMark) (floating 1))
 
-  (rule $InitChannelDef ($InitChannel $InitField)
-        (interactive.JsonInitFn NormalChannel) (floating 1))
-  (rule $InitChannelDef ($InitChannel $InitField)
-        (interactive.JsonInitFn AggregateChannel) (floating 1))
-  (rule $InitChannelDef ($InitChannel)
-        (interactive.JsonInitFn CountChannel) (floating 1))
-
-  (rule $InitChannelDefs ($InitChannelDef)
-        (lambda d (:s (var d))) (floating 1))
-  (rule $InitChannelDefs ($InitChannelDefs $InitChannelDef)
-        (interactive.JsonInitFn Combine) (floating 1))
-
-  (rule $InitConcreteChannelDefs ($InitChannelDefs)
-        (interactive.JsonInitFn Concretize) (floating 1))
   (rule $ROOT ($InitMark $InitConcreteChannelDefs)
-        (lambda m (lambda ccds (: init (var m) (var ccds)))) (floating 1))
+        (interactive.JsonInitFn Finalize) (floating 1))
 
 )

--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -57,7 +57,9 @@
   (rule $InitChannelDefs ($InitChannelDefs $InitChannelDef)
         (interactive.JsonInitFn Combine) (floating 1))
 
-  (rule $ROOT ($InitMark $InitChannelDefs)
+  (rule $InitConcreteChannelDefs ($InitChannelDefs)
         (interactive.JsonInitFn Concretize) (floating 1))
+  (rule $ROOT ($InitMark $InitConcreteChannelDefs)
+        (lambda m (lambda ccds (: init (var m) (var ccds)))) (floating 1))
 
 )

--- a/plot/plot.grammar
+++ b/plot/plot.grammar
@@ -35,10 +35,28 @@
 
 ################################
 # Initial Plot Generation
-# Inspired by Voyager 2 suggestion algorithm
 
 (when init-plot
 
+  (rule $InitChannel ($Regular) (interactive.VegaFn Channel))
+  (rule $InitChannel (anyvalue) (ConstantFn *) (floating 1))
+  (rule $InitField ($Regular) (interactive.VegaFn Field))
+  (rule $InitField (anyvalue) (ConstantFn *) (floating 1))
+  (rule $InitMark ($Regular) (interactive.VegaFn Mark))
+  (rule $InitMark (anyvalue) (interactive.JsonInitFn AnyMark) (floating 1))
 
+  (rule $InitChannelDef ($InitChannel $InitField)
+        (interactive.JsonInitFn NormalChannel) (floating 1))
+  (rule $InitChannelDef ($InitField)
+        (interactive.JsonInitFn AggregateChannel) (floating 1))
+  (rule $InitChannelDef (anyvalue)
+        (interactive.JsonInitFn CountChannel) (floating 1))
+
+  (rule $InitChannelDefs ($InitChannelDef) (IdentityFn) (floating 1))
+  (rule $InitChannelDefs ($InitChannelDefs $InitChannelDef)
+        (interactive.JsonInitFn Combine) (floating 1))
+
+  (rule $ROOT ($InitMark $InitChannelDefs)
+        (interactive.JsonInitFn Concretize) (floating 1))
 
 )

--- a/plot/run
+++ b/plot/run
@@ -128,7 +128,7 @@ addMode('plot', 'interactive semantic parsing for plotting', lambda { |e| l(
 
   o('JsonMaster.intOutputPath', './plot-out/'),
   o('InteractiveServer.numThreads', 8),
-  o('InteractiveServer.maxCandidates', 200),
+  o('InteractiveServer.maxCandidates', 100),
   o('InteractiveServer.queryLogPath', './plot-out/query.jsonl'),
   o('InteractiveServer.responseLogPath', './plot-out/response.jsonl'),
   o('InteractiveServer.port', 8405),
@@ -142,9 +142,9 @@ addMode('plot', 'interactive semantic parsing for plotting', lambda { |e| l(
   o('VegaResources.vegaSchema', "./#{$path}/vega-lite-v2.json"),
   o('VegaResources.excludedPaths', 'items', 'vconcat', 'hconcat', 'layer', 'spec', 'repeat'),
   o('VegaResources.colorFile', "./#{$path}/css-color-names.json"),
-  o('VegaResources.vegaSpecifications', "./#{$path}/templates/population", "./#{$path}/templates/cars", "./#{$path}/templates/stocks"),
+  # o('VegaResources.vegaSpecifications', "./#{$path}/templates/population", "./#{$path}/templates/cars", "./#{$path}/templates/stocks"),
   o('VegaResources.initialTemplates', "./#{$path}/initial-templates.json"),
-  selo(0, 'VegaResources.allVegaJsonPaths', "./#{$path}/vega-lite-paths.txt", "./plot-out/PathInTemplates.txt"),
+  # selo(0, 'VegaResources.allVegaJsonPaths', "./#{$path}/vega-lite-paths.txt", "./plot-out/PathInTemplates.txt"),
 
   o('VegaEngine.verbose', 0),
   o('VegaExecutor.compileVega', false),

--- a/src/edu/stanford/nlp/sempre/ParserState.java
+++ b/src/edu/stanford/nlp/sempre/ParserState.java
@@ -139,6 +139,10 @@ public abstract class ParserState {
       HashSet<Formula> uniqueFormulas = new HashSet<>();
       List<Derivation> derivsByFormula = new ArrayList<>();
       for (Derivation d : derivations) {
+        if (d == null) {
+          LogInfo.logs("ParserState.mapToFormula: null derivation");
+          continue;
+        }
         boolean contains  = uniqueFormulas.contains(d.formula);
         if (Parser.opts.verbose > 2)
           LogInfo.logs("ParserState.mapToFormula contains:%s (%s) %s in %s", contains, cellDescription, d.formula, uniqueFormulas);

--- a/src/edu/stanford/nlp/sempre/ValueFormula.java
+++ b/src/edu/stanford/nlp/sempre/ValueFormula.java
@@ -28,6 +28,6 @@ public class ValueFormula<T extends Value> extends PrimitiveFormula {
   }
 
   public int computeHashCode() {
-    return value.hashCode();
+    return value == null ? 0 : value.hashCode();
   }
 }

--- a/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
@@ -309,6 +309,31 @@ public class JsonFn extends SemanticFn {
     }
   }
 
+  static class ConstantValueStream extends MultipleDerivationStream {
+    List<JsonValue> values = new ArrayList<JsonValue>();
+    int index = 0;
+    Callable callable;
+
+    public ConstantValueStream(Example ex, Callable c) {
+      callable = c;
+      values.add(new JsonValue(false).withSchemaType("boolean"));
+      values.add(new JsonValue(true).withSchemaType("boolean"));
+      values.add(new JsonValue(0.0).withSchemaType("number"));
+    }
+
+    public Derivation createDerivation() {
+      if (index >= values.size())
+        return null;
+      JsonValue value = values.get(index);
+      index++;
+      Formula formula = new ValueFormula<JsonValue>(value);
+      return new Derivation.Builder()
+        .withCallable(callable)
+        .formula(formula)
+        .createDerivation();
+    }
+  }
+
   // Generate all possible full paths
   static class AnyPathStream extends MultipleDerivationStream {
     static List<NameValue> paths = null;

--- a/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
@@ -86,7 +86,6 @@ public class JsonFn extends SemanticFn {
 
   static class TemplateStream extends MultipleDerivationStream {
     Callable callable;
-    int currIndex = 0;
     private Iterator<Entry<String, String>> templatesIterator;
 
     public TemplateStream(Callable c) {

--- a/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
@@ -336,17 +336,18 @@ public class JsonFn extends SemanticFn {
 
   // Generate all possible full paths
   static class AnyPathStream extends MultipleDerivationStream {
-    static List<NameValue> paths = null;
+    static List<NameValue> paths = new ArrayList<>();
     int index = 0;
     Callable callable;
 
     public AnyPathStream(Example ex, Callable c) {
       callable = c;
-      if (paths == null) {
-        // Only initialize once
-        paths = new ArrayList<>();
-        for (List<String> path : VegaResources.allPathsMatcher.getPaths()) {
-          paths.add(new NameValue("$." + String.join(".", path)));
+      synchronized (paths) {
+        if (paths.isEmpty()) {
+          // Only initialize once
+          for (List<String> path : VegaResources.allPathsMatcher.getPaths()) {
+            paths.add(new NameValue("$." + String.join(".", path)));
+          }
         }
       }
     }

--- a/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonFn.java
@@ -70,42 +70,14 @@ public class JsonFn extends SemanticFn {
       return new IsPathStream(ex, c);
     } else if (mode == Mode.JsonValue) {
       return new JsonValueStream(ex, c);
-    } else if (mode == Mode.ConstantValue) {
-      return new ConstantValueStream(ex, c);
     } else if (mode == Mode.AnyPath) {
       return new AnyPathStream(ex, c);
     } else if (mode == Mode.AnyPathElement) {
       return new AnyPathElementStream(ex, c);
     } else if (mode == Mode.Join) {
       return new JoinStream(ex, c);
-    } else if (mode == Mode.Template) {
-      return new TemplateStream(c);
     }
     return null;
-  }
-
-  static class TemplateStream extends MultipleDerivationStream {
-    Callable callable;
-    int currIndex = 0;
-    private Iterator<Entry<String, String>> templatesIterator;
-
-    public TemplateStream(Callable c) {
-      callable = c;
-      this.templatesIterator = VegaResources.templatesMap.entrySet().stream()
-          .filter(s -> s.getKey().contains(c.childStringValue(0))).iterator();
-    }
-
-    @Override
-    public Derivation createDerivation() {
-      if (!templatesIterator.hasNext()) return null;
-
-      Formula formula = new ValueFormula<>(new NameValue(templatesIterator.next().getKey()));
-      // change to using just the name of the template
-      return new Derivation.Builder()
-          .withCallable(callable)
-          .formula(formula)
-          .createDerivation();
-    }
   }
 
   static class JoinStream extends MultipleDerivationStream {
@@ -153,10 +125,6 @@ public class JsonFn extends SemanticFn {
         nextPath();
         return currentValue;
       }
-    }
-
-    private Iterator<JsonValue> getValue(List<String> path, List<JsonValue> values) {
-      return null;
     }
 
     public JoinStream(Example ex, Callable c) {
@@ -335,31 +303,6 @@ public class JsonFn extends SemanticFn {
       } else {
         value = new JsonValue(string).withSchemaType("string");
       }
-      Formula formula = new ValueFormula<JsonValue>(value);
-      return new Derivation.Builder()
-          .withCallable(callable)
-          .formula(formula)
-          .createDerivation();
-    }
-  }
-
-  static class ConstantValueStream extends MultipleDerivationStream {
-    List<JsonValue> values = new ArrayList<JsonValue>();
-    int index = 0;
-    Callable callable;
-
-    public ConstantValueStream(Example ex, Callable c) {
-      callable = c;
-      values.add(new JsonValue(false).withSchemaType("boolean"));
-      values.add(new JsonValue(true).withSchemaType("boolean"));
-      values.add(new JsonValue(0.0).withSchemaType("number"));
-    }
-
-    public Derivation createDerivation() {
-      if (index >= values.size())
-        return null;
-      JsonValue value = values.get(index);
-      index++;
       Formula formula = new ValueFormula<JsonValue>(value);
       return new Derivation.Builder()
           .withCallable(callable)

--- a/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
@@ -361,14 +361,15 @@ public class JsonInitFn extends SemanticFn {
       if (("area".equals(mark) || "line".equals(mark))
           && !(channelNames.contains("x") && channelNames.contains("y")))
         return false;
-      // Count can only appear when all other fields are ordinal
-      boolean hasCount = false, hasNonOrdinal = false;
+      // Count can only appear when all other fields are ordinal / nominal
+      boolean hasCount = false, hasNonDiscrete = false;
       for (Formula c : channelDefs) {
         ChannelDefFormula channelDef = (ChannelDefFormula) c;
         if ("count".equals(channelDef.defValue("aggregate"))) hasCount = true;
-        if (!"ordinal".equals(channelDef.defValue("type"))) hasNonOrdinal = true;
+        String type = channelDef.defValue("type");
+        if (!("ordinal".equals(type) || "nominal".equals(type))) hasNonDiscrete = true;
       }
-      if (hasCount && hasNonOrdinal) return false;
+      if (hasCount && hasNonDiscrete) return false;
       // TODO: Add more constraints
       return true;
     }

--- a/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
@@ -1,0 +1,36 @@
+package edu.stanford.nlp.sempre.interactive;
+
+import java.util.*;
+
+import edu.stanford.nlp.sempre.*;
+import fig.basic.LispTree;
+import fig.basic.Option;
+
+/**
+ * Semantic functions for generating a new plot.
+ * @author ppasupat
+ */
+public class JsonInitFn extends SemanticFn {
+  public static class Options {
+    @Option(gloss = "verbosity")
+    public int verbose = 0;
+  }
+  public static Options opts = new Options();
+
+  Formula arg1, arg2;
+  enum Mode {AnyMark, NormalChannel, AggregateChannel, CountChannel, Combine, Concretize};
+  Mode mode;
+  DerivationStream stream;
+
+  @Override
+  public void init(LispTree tree) {
+    super.init(tree);
+    mode = Mode.valueOf(tree.child(1).toString());
+  }
+
+  @Override
+  public DerivationStream call(final Example ex, final Callable c) {
+    return null;
+  }
+
+}

--- a/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
@@ -30,7 +30,150 @@ public class JsonInitFn extends SemanticFn {
 
   @Override
   public DerivationStream call(final Example ex, final Callable c) {
-    return null;
+    switch (mode) {
+      case AnyMark:
+        return new AnyMarkStream(ex, c);
+      case NormalChannel:
+        return new NormalChannelStream(ex, c);
+      case AggregateChannel:
+        return new AggregateChannelStream(ex, c);
+      case CountChannel:
+        return new CountChannelStream(ex, c);
+      case Combine:
+        return new CombineStream(ex, c);
+      case Concretize:
+        //return new ConcretizeStream(ex, c);
+      default:
+        throw new RuntimeException("Unrecognized mode: " + mode);
+    }
+  }
+
+  // ============================================================
+  // AnyMark
+  // ============================================================
+
+  /**
+   * Generate a ValueFormula(JsonValue(s)) for each possible mark s ("bar", "line", etc.)
+   */
+  static class AnyMarkStream extends MultipleDerivationStream {
+    Callable callable;
+    Iterator<String> markIterator;
+
+    public AnyMarkStream(Example ex, Callable c) {
+      callable = c;
+      markIterator = VegaResources.MARKS.iterator();
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      if (!markIterator.hasNext()) return null;
+      JsonValue value = new JsonValue(markIterator.next()).withSchemaType("string");
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(new ValueFormula<>(value))
+          .createDerivation();
+    }
+  }
+
+  // ============================================================
+  // Channel creation
+  // ============================================================
+
+  static final ValueFormula<NameValue> NORMAL_CHANNEL = new ValueFormula<>(new NameValue("c_nrm"));
+  static final ValueFormula<NameValue> AGGREGATE_CHANNEL = new ValueFormula<>(new NameValue("c_agg"));
+  static final ValueFormula<NameValue> COUNT_CHANNEL = new ValueFormula<>(new NameValue("c_cnt"));
+
+  static class NormalChannelStream extends SingleDerivationStream {
+    Callable callable;
+
+    public NormalChannelStream(Example ex, Callable c) {
+      callable = c;
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      Formula channel = callable.child(0).formula, field = callable.child(1).formula;
+      Formula formula = new ActionFormula(ActionFormula.Mode.primitive,
+          Arrays.asList(NORMAL_CHANNEL, channel, field));
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(formula)
+          .createDerivation();
+    }
+  }
+
+  static class AggregateChannelStream extends SingleDerivationStream {
+    Callable callable;
+
+    public AggregateChannelStream(Example ex, Callable c) {
+      callable = c;
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      Formula channel = callable.child(0).formula, field = callable.child(1).formula;
+      Formula formula = new ActionFormula(ActionFormula.Mode.primitive,
+          Arrays.asList(AGGREGATE_CHANNEL, channel, field));
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(formula)
+          .createDerivation();
+    }
+  }
+
+  static class CountChannelStream extends SingleDerivationStream {
+    Callable callable;
+
+    public CountChannelStream(Example ex, Callable c) {
+      callable = c;
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      Formula channel = callable.child(0).formula;
+      Formula formula = new ActionFormula(ActionFormula.Mode.primitive,
+          Arrays.asList(COUNT_CHANNEL, channel));
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(formula)
+          .createDerivation();
+    }
+  }
+
+  // ============================================================
+  // Combine
+  // ============================================================
+
+  static class CombineStream extends SingleDerivationStream {
+    Callable callable;
+
+    public CombineStream(Example ex, Callable c) {
+      callable = c;
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      return null;
+    }
+  }
+
+  // ============================================================
+  // Concretize
+  // ============================================================
+
+  static class ConcretizeStream extends MultipleDerivationStream {
+    Example ex;
+    Callable callable;
+
+    public ConcretizeStream(Example ex, Callable c) {
+      this.ex = ex;
+      callable = c;
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      return null;
+    }
   }
 
 }

--- a/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
@@ -153,6 +153,10 @@ public class JsonInitFn extends SemanticFn {
       this.fieldName = def.has("field") ? def.get("field").textValue() : "*";
       this.def = def;
     }
+
+    public String defValue(String key) {
+      return def.has(key) ? def.get(key).textValue() : null;
+    }
   }
 
   static final Map<String, List<String>> DATA_TYPE_TO_SPEC_TYPES = new HashMap<>();
@@ -357,6 +361,14 @@ public class JsonInitFn extends SemanticFn {
       if (("area".equals(mark) || "line".equals(mark))
           && !(channelNames.contains("x") && channelNames.contains("y")))
         return false;
+      // Count can only appear when all other fields are ordinal
+      boolean hasCount = false, hasNonOrdinal = false;
+      for (Formula c : channelDefs) {
+        ChannelDefFormula channelDef = (ChannelDefFormula) c;
+        if ("count".equals(channelDef.defValue("aggregate"))) hasCount = true;
+        if (!"ordinal".equals(channelDef.defValue("type"))) hasNonOrdinal = true;
+      }
+      if (hasCount && hasNonOrdinal) return false;
       // TODO: Add more constraints
       return true;
     }

--- a/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
@@ -42,7 +42,7 @@ public class JsonInitFn extends SemanticFn {
       case Combine:
         return new CombineStream(ex, c);
       case Concretize:
-        //return new ConcretizeStream(ex, c);
+        return new ConcretizeStream(ex, c);
       default:
         throw new RuntimeException("Unrecognized mode: " + mode);
     }

--- a/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
@@ -6,12 +6,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import edu.stanford.nlp.sempre.*;
-import edu.stanford.nlp.util.Pair;
 import fig.basic.LispTree;
 import fig.basic.Option;
 
 /**
  * Semantic functions for generating a new plot.
+ *
+ * Use generation procedure from https://github.com/vega/voyager2/blob/vy2-master/src/app/alternatives/alternatives.service.js
+ *
+ * Use constraints from https://github.com/vega/compassql/tree/master/src/constraint
+ *
  * @author ppasupat
  */
 public class JsonInitFn extends SemanticFn {
@@ -21,8 +25,7 @@ public class JsonInitFn extends SemanticFn {
   }
   public static Options opts = new Options();
 
-  Formula arg1, arg2;
-  enum Mode {AnyMark, NormalChannel, AggregateChannel, CountChannel, Combine, Concretize};
+  enum Mode {AnyChannel, AnyField, AnyMark, ChannelDef, CombineDefs, Finalize};
   Mode mode;
   DerivationStream stream;
 
@@ -35,43 +38,89 @@ public class JsonInitFn extends SemanticFn {
   @Override
   public DerivationStream call(final Example ex, final Callable c) {
     switch (mode) {
+      case AnyChannel:
+        return new AnyChannelStream(ex, c);
+      case AnyField:
+        return new AnyFieldStream(ex, c);
       case AnyMark:
         return new AnyMarkStream(ex, c);
-      case NormalChannel:
-        return new NormalChannelStream(ex, c);
-      case AggregateChannel:
-        return new AggregateChannelStream(ex, c);
-      case CountChannel:
-        return new CountChannelStream(ex, c);
-      case Combine:
-        return new CombineStream(ex, c);
-      case Concretize:
-        return new ConcretizeStream(ex, c);
+      case ChannelDef:
+        return new ChannelDefStream(ex, c);
+      case CombineDefs:
+        return new CombineDefsStream(ex, c);
+      case Finalize:
+        return new FinalizeStream(ex, c);
       default:
         throw new RuntimeException("Unrecognized mode: " + mode);
     }
   }
 
   // ============================================================
-  // AnyMark
+  // AnyChannel, AnyField, AnyMark
   // ============================================================
+
+  /**
+   * Generate a ValueFormula(JsonValue(s)) for each possible channel s ("x", "y", etc.)
+   */
+  static class AnyChannelStream extends MultipleDerivationStream {
+    Callable callable;
+    Iterator<String> itr;
+
+    public AnyChannelStream(Example ex, Callable c) {
+      callable = c;
+      itr = VegaResources.CHANNELS.iterator();
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      if (!itr.hasNext()) return null;
+      JsonValue value = new JsonValue(itr.next()).withSchemaType("string");
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(new ValueFormula<>(value))
+          .createDerivation();
+    }
+  }
+
+  /**
+   * Generate a ValueFormula(JsonValue(s)) for each possible data field s
+   */
+  static class AnyFieldStream extends MultipleDerivationStream {
+    Callable callable;
+    Iterator<VegaJsonContextValue.Field> itr;
+
+    public AnyFieldStream(Example ex, Callable c) {
+      callable = c;
+      itr = ((VegaJsonContextValue) ex.context).getFields().iterator();
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      if (!itr.hasNext()) return null;
+      JsonValue value = new JsonValue(itr.next().name).withSchemaType("string");
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(new ValueFormula<>(value))
+          .createDerivation();
+    }
+  }
 
   /**
    * Generate a ValueFormula(JsonValue(s)) for each possible mark s ("bar", "line", etc.)
    */
   static class AnyMarkStream extends MultipleDerivationStream {
     Callable callable;
-    Iterator<String> markIterator;
+    Iterator<String> itr;
 
     public AnyMarkStream(Example ex, Callable c) {
       callable = c;
-      markIterator = VegaResources.MARKS.iterator();
+      itr = VegaResources.MARKS.iterator();
     }
 
     @Override
     public Derivation createDerivation() {
-      if (!markIterator.hasNext()) return null;
-      JsonValue value = new JsonValue(markIterator.next()).withSchemaType("string");
+      if (!itr.hasNext()) return null;
+      JsonValue value = new JsonValue(itr.next()).withSchemaType("string");
       return new Derivation.Builder()
           .withCallable(callable)
           .formula(new ValueFormula<>(value))
@@ -83,151 +132,26 @@ public class JsonInitFn extends SemanticFn {
   // Channel creation
   // ============================================================
 
-  static final ValueFormula<NameValue> NORMAL_CHANNEL = new ValueFormula<>(new NameValue("c_nrm"));
-  static final ValueFormula<NameValue> AGGREGATE_CHANNEL = new ValueFormula<>(new NameValue("c_agg"));
-  static final ValueFormula<NameValue> COUNT_CHANNEL = new ValueFormula<>(new NameValue("c_cnt"));
-  static final ValueFormula<NameValue> STAR = new ValueFormula<>(new NameValue("*"));
-
-  static class NormalChannelStream extends SingleDerivationStream {
-    Callable callable;
-
-    public NormalChannelStream(Example ex, Callable c) {
-      callable = c;
-    }
-
-    @Override
-    public Derivation createDerivation() {
-      Formula channel = callable.child(0).formula, field = callable.child(1).formula;
-      Formula formula = new ActionFormula(ActionFormula.Mode.primitive,
-          Arrays.asList(NORMAL_CHANNEL, channel, field));
-      return new Derivation.Builder()
-          .withCallable(callable)
-          .formula(formula)
-          .createDerivation();
-    }
+  static final Map<String, List<String>> DATA_TYPE_TO_SPEC_TYPES = new HashMap<>();
+  static {
+    DATA_TYPE_TO_SPEC_TYPES.put("string", Arrays.asList("nominal", "ordinal"));
+    DATA_TYPE_TO_SPEC_TYPES.put("integer", Arrays.asList("ordinal", "quantitative"));
+    DATA_TYPE_TO_SPEC_TYPES.put("number", Arrays.asList("ordinal", "quantitative"));
+    DATA_TYPE_TO_SPEC_TYPES.put("date", Arrays.asList("ordinal", "temporal"));
   }
 
-  static class AggregateChannelStream extends SingleDerivationStream {
+  /**
+   * Generate a channel definition as (: "channel" channelKey channelValue)
+   */
+  static class ChannelDefStream extends MultipleDerivationStream {
     Callable callable;
-
-    public AggregateChannelStream(Example ex, Callable c) {
-      callable = c;
-    }
-
-    @Override
-    public Derivation createDerivation() {
-      Formula channel = callable.child(0).formula, field = callable.child(1).formula;
-      // Check if field can be aggregated
-      // TODO
-      Formula formula = new ActionFormula(ActionFormula.Mode.primitive,
-          Arrays.asList(AGGREGATE_CHANNEL, channel, field));
-      return new Derivation.Builder()
-          .withCallable(callable)
-          .formula(formula)
-          .createDerivation();
-    }
-  }
-
-  static class CountChannelStream extends SingleDerivationStream {
-    Callable callable;
-
-    public CountChannelStream(Example ex, Callable c) {
-      callable = c;
-    }
-
-    @Override
-    public Derivation createDerivation() {
-      Formula channel = callable.child(0).formula;
-      Formula formula = new ActionFormula(ActionFormula.Mode.primitive,
-          Arrays.asList(COUNT_CHANNEL, channel, STAR));
-      return new Derivation.Builder()
-          .withCallable(callable)
-          .formula(formula)
-          .createDerivation();
-    }
-  }
-
-  // ============================================================
-  // Combine
-  // ============================================================
-
-  static class CombineStream extends SingleDerivationStream {
-    Callable callable;
-
-    public CombineStream(Example ex, Callable c) {
-      callable = c;
-    }
-
-    @Override
-    public Derivation createDerivation() {
-      ActionFormula oldList = (ActionFormula) callable.child(0).formula,
-                   newEntry = (ActionFormula) callable.child(1).formula;
-      assert oldList.mode == ActionFormula.Mode.sequential;
-      List<Formula> combined = new ArrayList<>(oldList.args);
-      combined.add(newEntry);
-      if (!checkChannelDefs(combined)) return null;
-      Formula newList = new ActionFormula(ActionFormula.Mode.sequential, combined);
-      return new Derivation.Builder()
-          .withCallable(callable)
-          .formula(newList)
-          .createDerivation();
-    }
-
-    /**
-     * Check the following conditions:
-     * - Maximum length = 4
-     * - Only one aggregate or count can be present, and must be the last entry
-     * - Fields must not be repeated
-     * - Channels must not be repeated
-     */
-    private boolean checkChannelDefs(List<Formula> combined) {
-      if (combined.size() > 4) return false;
-      List<Value> usedChannels = new ArrayList<>(), usedFields = new ArrayList<>();
-      for (int i = 0; i < combined.size(); i++) {
-        ActionFormula channelDef = (ActionFormula) combined.get(i);
-        Formula type = channelDef.args.get(0);
-        if (!type.equals(NORMAL_CHANNEL) && i != combined.size() - 1)
-          return false;
-        Value channel = ((ValueFormula<?>) channelDef.args.get(1)).value,
-                field = ((ValueFormula<?>) channelDef.args.get(2)).value;
-        if (!channel.equals(STAR.value)) {
-          if (usedChannels.contains(channel)) return false;
-          usedChannels.add(channel);
-        }
-        if (!field.equals(STAR.value)) {
-          if (usedFields.contains(field)) return false;
-          usedFields.add(field);
-        }
-      }
-      return true;
-    }
-  }
-
-  // ============================================================
-  // Concretize
-  // ============================================================
-
-  static final ValueFormula<NameValue> INIT = new ValueFormula<>(new NameValue("init"));
-
-  static class ConcretizeStream extends MultipleDerivationStream {
-    Example ex;
-    Callable callable;
-    List<Formula> abstractChannelDefs;
-    List<Pair<String, JsonNode>> concreteChannelDefs;
-    List<Formula> concretizations = new ArrayList<>();
+    VegaJsonContextValue context;
     Iterator<Formula> itr;
 
-    public ConcretizeStream(Example ex, Callable c) {
-      this.ex = ex;
+    public ChannelDefStream(Example ex, Callable c) {
       callable = c;
-      ActionFormula child = (ActionFormula) callable.child(0).formula;
-      assert child.mode == ActionFormula.Mode.sequential;
-      abstractChannelDefs = child.args;
-      concreteChannelDefs = new ArrayList<>();
-      for (int i = 0; i < abstractChannelDefs.size(); i++)
-        concreteChannelDefs.add(null);
-      initConcretizations(0);
-      itr = concretizations.iterator();
+      context = (VegaJsonContextValue) ex.context;
+      itr = generate().iterator();
     }
 
     @Override
@@ -239,28 +163,130 @@ public class JsonInitFn extends SemanticFn {
           .createDerivation();
     }
 
-    // Depth first search
-    private void initConcretizations(int index) {
-      if (index == abstractChannelDefs.size()) {
-        ObjectNode node = Json.getMapper().createObjectNode();
-        for (Pair<String, JsonNode> kv : concreteChannelDefs) {
-          node.put(kv.first, kv.second);
+    private List<Formula> generate() {
+      List<Formula> formulas = new ArrayList<>();
+      Formula channelFormula = callable.child(0).formula;
+      String channelName = formulaToString(channelFormula),
+               fieldName = formulaToString(callable.child(1).formula);
+      if ("*".equals(fieldName) && checkCountChannel(channelName)) {
+        // COUNT channel
+        ObjectNode obj = Json.getMapper().createObjectNode();
+        obj.put("type", "quantitative").put("aggregate", "count");
+        Formula channelValue = new ValueFormula<JsonValue>(new JsonValue(obj));
+        formulas.add(new ActionFormula(ActionFormula.Mode.primitive,
+            Arrays.asList(channelFormula, channelValue)));
+      } else {
+        VegaJsonContextValue.Field field = context.getField(fieldName);
+        for (String specType : DATA_TYPE_TO_SPEC_TYPES.get(field.type)) {
+          // NORMAL channel
+          if (checkNormalChannel(channelName, specType)) {
+            ObjectNode obj = Json.getMapper().createObjectNode();
+            obj.put("field", fieldName).put("type", specType);
+            Formula channelValue = new ValueFormula<JsonValue>(new JsonValue(obj));
+            formulas.add(new ActionFormula(ActionFormula.Mode.primitive,
+                Arrays.asList(channelFormula, channelValue)));
+          }
+          // AGGREGATE channel
+          if (checkAggregateChannel(channelName, specType)) {
+            for (String aggregateType : VegaResources.AGGREGATES) {
+              ObjectNode obj = Json.getMapper().createObjectNode();
+              obj.put("field", fieldName).put("type", specType).put("aggregate", aggregateType);
+              Formula channelValue = new ValueFormula<JsonValue>(new JsonValue(obj));
+              formulas.add(new ActionFormula(ActionFormula.Mode.primitive,
+                  Arrays.asList(channelFormula, channelValue)));
+            }
+          }
         }
-        concretizations.add(new ValueFormula<>(new JsonValue(node)));
-        return;
       }
-      ActionFormula abstractChannelDef = (ActionFormula) abstractChannelDefs.get(index);
-      Formula type = abstractChannelDef.args.get(0);
-      Value channel = ((ValueFormula<?>) abstractChannelDef.args.get(1)).value,
-              field = ((ValueFormula<?>) abstractChannelDef.args.get(2)).value;
-      if (type.equals(NORMAL_CHANNEL)) {
-        ObjectNode node = Json.getMapper().createObjectNode();
-        node.put("field", "a");
-        concreteChannelDefs.set(index, new Pair<>("x", node));
-        initConcretizations(index + 1);
-      }
+      return formulas;
     }
 
+    private String formulaToString(Formula f) {
+      Value v = ((ValueFormula<?>) f).value;
+      if (v instanceof NameValue) {
+        return ((NameValue) v).id;
+      } else if (v instanceof JsonValue) {
+        return ((JsonValue) v).getJsonNode().textValue();
+      }
+      throw new RuntimeException("Cannot convert " + f + " to string");
+    }
+
+    private boolean checkCountChannel(String channelName) {
+      return !(
+          "row".equals(channelName) || "column".equals(channelName) || "shape".equals(channelName));
+    }
+
+    private boolean checkNormalChannel(String channelName, String specType) {
+      if ("row".equals(channelName) || "column".equals(channelName))
+        return "ordinal".equals(specType) || "nominal".equals(specType);
+      if ("opacity".equals(channelName) || "size".equals(channelName) ||
+          "x2".equals(channelName) || "y2".equals(channelName))
+        return "quantitative".equals(specType) || "temporal".equals(specType);
+      if ("shape".equals(channelName))
+        return "nominal".equals(specType);
+      return true;
+    }
+
+    private boolean checkAggregateChannel(String channelName, String specType) {
+      return "quantitative".equals(specType) && !(
+          "row".equals(channelName) || "column".equals(channelName) || "shape".equals(channelName));
+    }
+  }
+
+  // ============================================================
+  // Combine
+  // ============================================================
+
+  static class CombineDefsStream extends MultipleDerivationStream {
+    Callable callable;
+    Iterator<Formula> itr;
+
+    public CombineDefsStream(Example ex, Callable c) {
+      callable = c;
+      itr = generate().iterator();
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      if (!itr.hasNext()) return null;
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(itr.next())
+          .createDerivation();
+    }
+
+    private List<Formula> generate() {
+      return new ArrayList<>();
+    }
+  }
+
+  // ============================================================
+  // Concretize
+  // ============================================================
+
+  static final ValueFormula<NameValue> INIT = new ValueFormula<>(new NameValue("init"));
+
+  static class FinalizeStream extends MultipleDerivationStream {
+    Callable callable;
+    Iterator<Formula> itr;
+
+    public FinalizeStream(Example ex, Callable c) {
+      callable = c;
+      itr = generate().iterator();
+    }
+
+    @Override
+    public Derivation createDerivation() {
+      if (!itr.hasNext()) return null;
+      return new Derivation.Builder()
+          .withCallable(callable)
+          .formula(itr.next())
+          .createDerivation();
+    }
+
+    private List<Formula> generate() {
+      return new ArrayList<>();
+    }
   }
 
 }

--- a/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
@@ -56,8 +56,8 @@ public class VegaExecutor extends Executor {
     if (context instanceof VegaJsonContextValue)
       jsonContext = (VegaJsonContextValue)context;
     else
-      jsonContext = new VegaJsonContextValue(Json.readMapHard((String)VegaResources.templates.get(0)));
-
+      throw new RuntimeException("VegaExecutor only allows VegaJsonContextValue");
+      
     formula = Formulas.betaReduction(formula);
     try {
       JsonNode result = execute((ActionFormula)formula, jsonContext);
@@ -116,10 +116,8 @@ public class VegaExecutor extends Executor {
         ObjectNode objNode = (ObjectNode) jsonContext.getJsonNode();
         JsonUtils.setPathValue(objNode, fullpath, ((JsonValue)value).getJsonNode());
         result = objNode;
-      } else if (id.equals("new")) {
-        Formula filename = f.args.get(1);
-        String key = Formulas.getString(filename);
-        return JsonUtils.toJsonNode(Json.readMapHard(VegaResources.templatesMap.get(key)));
+      } else {
+        throw new RuntimeException("VegaExecutor: formula not implemented: " + f);
       }
     }
     if (opts.verbose >= 1) {

--- a/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
@@ -125,6 +125,7 @@ public class VegaExecutor extends Executor {
         for (int i = 2; i < f.args.size(); i++) {
           Formula encoding = f.args.get(i);
         }
+        // TODO: Return a new graph!
       }
     }
     if (opts.verbose >= 1) {

--- a/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
@@ -57,7 +57,7 @@ public class VegaExecutor extends Executor {
       jsonContext = (VegaJsonContextValue)context;
     else
       throw new RuntimeException("VegaExecutor only allows VegaJsonContextValue");
-      
+
     formula = Formulas.betaReduction(formula);
     try {
       JsonNode result = execute((ActionFormula)formula, jsonContext);
@@ -103,6 +103,7 @@ public class VegaExecutor extends Executor {
 
   @SuppressWarnings("rawtypes")
   private JsonNode execute(ActionFormula f, VegaJsonContextValue jsonContext) {
+    System.out.println(f);
     JsonNode result = null;
     if (f.mode == ActionFormula.Mode.primitive) {
       // use reflection to call primitive stuff
@@ -117,11 +118,14 @@ public class VegaExecutor extends Executor {
         JsonUtils.setPathValue(objNode, fullpath, ((JsonValue)value).getJsonNode());
         result = objNode;
       } else if (id.equals("init")) {
-        Formula mark = f.args.get(1);
-        for (int i = 2; i < f.args.size(); i++) {
-          Formula encoding = f.args.get(i);
-        }
-        // TODO: Return a new graph!
+        JsonNode mark = ((JsonValue) ((ValueFormula) f.args.get(1)).value).getJsonNode();
+        JsonNode encoding = ((JsonValue) ((ValueFormula) f.args.get(2)).value).getJsonNode();
+        ObjectNode objNode = Json.getMapper().createObjectNode();
+        objNode.put("$schema", "https://vega.github.io/schema/vega-lite/v2.json");
+        objNode.put("mark", mark);
+        objNode.put("encoding", encoding);
+        System.out.println(objNode.toString());
+        result = objNode;
       } else {
         throw new RuntimeException("VegaExecutor: formula not implemented: " + f);
       }

--- a/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
@@ -120,6 +120,11 @@ public class VegaExecutor extends Executor {
         Formula filename = f.args.get(1);
         String key = Formulas.getString(filename);
         return JsonUtils.toJsonNode(Json.readMapHard(VegaResources.templatesMap.get(key)));
+      } else if (id.equals("init")) {
+        Formula mark = f.args.get(1);
+        for (int i = 2; i < f.args.size(); i++) {
+          Formula encoding = f.args.get(i);
+        }
       }
     }
     if (opts.verbose >= 1) {

--- a/src/edu/stanford/nlp/sempre/interactive/VegaFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaFn.java
@@ -1,5 +1,6 @@
 package edu.stanford.nlp.sempre.interactive;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Function;
@@ -30,7 +31,7 @@ public class VegaFn extends SemanticFn {
   }
 
   public static Options opts = new Options();
-  enum Mode {Enum, Field, Color};
+  enum Mode {Enum, Field, Color, Channel, Mark};
   Mode mode;
 
   @Override
@@ -38,6 +39,10 @@ public class VegaFn extends SemanticFn {
     super.init(tree);
     mode = Mode.valueOf(tree.child(1).toString());
   }
+
+  static final Set<String> CHANNELS = Sets.newHashSet("x", "y", "color", "opacity", "shape", "size", "row", "column");
+  static final Set<String> MARKS = Sets.newHashSet("area", "bar", "circle", "line", "point", "rect", "rule", "square", "text", "tick");
+
 
   @Override
   public DerivationStream call(final Example ex, final Callable c) {
@@ -58,6 +63,22 @@ public class VegaFn extends SemanticFn {
             if (s.equals(field.textValue()))
               return Sets.newHashSet("field");
           }
+        }
+        return null;
+      });
+    } else if (mode == Mode.Channel) {
+      // TODO: Remove this hack
+      return new VegaValueStream(ex, c, s -> {
+        if (CHANNELS.contains(s)) {
+          return Sets.newHashSet("string");
+        }
+        return null;
+      });
+    } else if (mode == Mode.Mark) {
+      // TODO: Remove this hack
+      return new VegaValueStream(ex, c, s -> {
+        if (MARKS.contains(s)) {
+          return Sets.newHashSet("string");
         }
         return null;
       });

--- a/src/edu/stanford/nlp/sempre/interactive/VegaFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaFn.java
@@ -1,6 +1,5 @@
 package edu.stanford.nlp.sempre.interactive;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Function;
@@ -40,10 +39,6 @@ public class VegaFn extends SemanticFn {
     mode = Mode.valueOf(tree.child(1).toString());
   }
 
-  static final Set<String> CHANNELS = Sets.newHashSet("x", "y", "color", "opacity", "shape", "size", "row", "column");
-  static final Set<String> MARKS = Sets.newHashSet("area", "bar", "circle", "line", "point", "rect", "rule", "square", "text", "tick");
-
-
   @Override
   public DerivationStream call(final Example ex, final Callable c) {
     if (mode == Mode.Enum) {
@@ -69,7 +64,7 @@ public class VegaFn extends SemanticFn {
     } else if (mode == Mode.Channel) {
       // TODO: Remove this hack
       return new VegaValueStream(ex, c, s -> {
-        if (CHANNELS.contains(s)) {
+        if (VegaResources.CHANNELS.contains(s)) {
           return Sets.newHashSet("string");
         }
         return null;
@@ -77,7 +72,7 @@ public class VegaFn extends SemanticFn {
     } else if (mode == Mode.Mark) {
       // TODO: Remove this hack
       return new VegaValueStream(ex, c, s -> {
-        if (MARKS.contains(s)) {
+        if (VegaResources.MARKS.contains(s)) {
           return Sets.newHashSet("string");
         }
         return null;

--- a/src/edu/stanford/nlp/sempre/interactive/VegaJsonContextValue.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaJsonContextValue.java
@@ -79,22 +79,27 @@ public class VegaJsonContextValue extends ContextValue {
     public String toString() { return name + "(" + type + ")"; }
   }
 
-  List<Field> fields;
+  protected Map<String, Field> fields;
 
   public VegaJsonContextValue setFields(Map<String, Map<String, Object>> schema) {
-    fields = new ArrayList<>();
+    fields = new HashMap<>();
     for (Map<String, Object> schemaItem : schema.values()) {
       if ("_id".equals(schemaItem.get("name"))) continue;     // Ignore dummy field
-      fields.add(new Field(schemaItem));
+      Field field = new Field(schemaItem);
+      fields.put(field.name, field);
     }
-    for (Field f : fields) {
+    for (Field f : fields.values()) {
       LogInfo.logs("Field %s (%s)", f.name, f.type);
     }
     return this;
   }
 
-  public List<Field> getFields() {
-    return fields;
+  public Collection<Field> getFields() {
+    return fields.values();
+  }
+
+  public Field getField(String name) {
+    return fields.get(name);
   }
 
 }

--- a/src/edu/stanford/nlp/sempre/interactive/VegaRandomizer.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaRandomizer.java
@@ -81,7 +81,7 @@ public class VegaRandomizer {
     ObjectNode allEncodings = mapper.createObjectNode();
     node.put("encoding", allEncodings);
     // Fill in the encoding
-    List<Field> fields = new ArrayList<>(context.fields);
+    List<Field> fields = new ArrayList<>(context.getFields());
     for (Map.Entry<String, String> templateEncoding : template.encoding.entrySet()) {
       ObjectNode encoding = mapper.createObjectNode();
       String channel = templateEncoding.getKey(), vegaType = templateEncoding.getValue(), aggregate = null;

--- a/src/edu/stanford/nlp/sempre/interactive/VegaResources.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaResources.java
@@ -62,6 +62,9 @@ public class VegaResources {
 
   private static Set<String> colorSet;
 
+  public static final Set<String> CHANNELS = Sets.newHashSet("x", "y", "color", "opacity", "shape", "size", "row", "column");
+  public static final Set<String> MARKS = Sets.newHashSet("area", "bar", "circle", "line", "point", "rect", "rule", "square", "text", "tick");
+
   static class InitialTemplate {
     @JsonProperty("mark") public String mark;
     @JsonProperty("encoding") public Map<String, String> encoding;

--- a/src/edu/stanford/nlp/sempre/interactive/VegaResources.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaResources.java
@@ -99,6 +99,11 @@ public class VegaResources {
       Json.prettyWriteValueHard(new File(savePath.toString()+".enums.json"),
           enumValueToTypes.keySet().stream().collect(Collectors.toList())
       );
+      Json.prettyWriteValueHard(new File(savePath.toString()+".enums-kv.json"),
+          enumValueToTypes.entrySet().stream().map(e -> {
+            return Lists.newArrayList(e.getKey(), e.getValue().stream().collect(Collectors.toList()));
+          }).collect(Collectors.toList())
+      );
 
       if (!Strings.isNullOrEmpty(opts.colorFile)) {
         colorSet = Json.readMapHard(String.join("\n", IOUtils.readLines(opts.colorFile))).keySet();

--- a/src/edu/stanford/nlp/sempre/interactive/VegaResources.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaResources.java
@@ -61,6 +61,7 @@ public class VegaResources {
 
   public static final Set<String> CHANNELS = Sets.newHashSet("x", "y", "color", "opacity", "shape", "size", "row", "column");
   public static final Set<String> MARKS = Sets.newHashSet("area", "bar", "circle", "line", "point", "rect", "rule", "square", "text", "tick");
+  public static final Set<String> AGGREGATES = Sets.newHashSet("max", "mean", "min", "median", "sum");
 
   static class InitialTemplate {
     @JsonProperty("mark") public String mark;

--- a/src/edu/stanford/nlp/sempre/interactive/VegaResources.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaResources.java
@@ -27,6 +27,9 @@ import fig.basic.MapUtils;
 import fig.basic.Option;
 import fig.basic.Pair;
 
+import java.util.concurrent.ThreadLocalRandom;
+
+
 /**
  * Vega-specific code that loads the schema, colors, and generate paths and type maps
  * @author sidaw
@@ -35,28 +38,22 @@ import fig.basic.Pair;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VegaResources {
   public static class Options {
-    @Option(gloss = "File or directory containing example vega specs") List<String> vegaSpecifications;
-    @Option(gloss = "File containing all valid VegaPaths") String allVegaJsonPaths;
     @Option(gloss = "File containing the vega schema") String vegaSchema;
-    @Option(gloss = "File containing object values to try") String valueTemplates;
     @Option(gloss = "Path elements to exclude") Set<String> excludedPaths;
     @Option(gloss = "File containing all the colors") String colorFile;
     @Option(gloss = "File containing initial plot templates") String initialTemplates;
+    @Option int verbose = 0;
   }
   public static Options opts = new Options();
   private final Path savePath = Paths.get(JsonMaster.opts.intOutputPath, "vegaResource");
-
 
   public static VegaLitePathMatcher allPathsMatcher;
   private static List<List<String>> filteredPaths;
   private static List<JsonSchema> descendents;
 
-  public static ArrayList<String> templates;
-  public static Map<String, String> templatesMap;
-
   public static JsonSchema vegaSchema;
 
-  private static Map<String, List<JsonValue>> typeToValues;
+  private static Map<String, List<JsonValue>> typeToValues = new HashMap<>();
   private static Map<String, Set<String>> enumValueToTypes;
   private static Map<String, Set<List<String>>> enumValueToPaths;
 
@@ -80,20 +77,14 @@ public class VegaResources {
       descendents = allDescendents.stream().filter(s -> s.node().has("type")).collect(Collectors.toList());
       LogInfo.logs("Got %d descendents, %d typed", allDescendents.size(), descendents.size());
 
-      if (opts.vegaSpecifications != null) {
-        LogInfo.begin_track("Loading examples from %s", opts.vegaSpecifications);
-        processVegaTemplates();
-        LogInfo.end_track();
-      }
-
-      filteredPaths = allSimplePaths();
+      filteredPaths = allSimplePaths(descendents);
       LogInfo.logs("Got %d distinct simple path not containing %s", filteredPaths.size(), opts.excludedPaths);
       allPathsMatcher = new VegaLitePathMatcher(filteredPaths);
       Json.prettyWriteValueHard(new File(savePath.toString()+".path_elements.json"),
           filteredPaths.stream().flatMap(List::stream)
           .collect(Collectors.toSet()).stream().collect(Collectors.toList()) );
 
-      // generate valueToTypes and valueToSet
+      // generate valueToTypes and valueToSet, for enum types
       generateValueMaps();
       LogInfo.logs("gathering valueToTypes: %d distinct enum values", enumValueToTypes.size());
       Json.prettyWriteValueHard(new File(savePath.toString()+".enums.json"),
@@ -119,7 +110,7 @@ public class VegaResources {
     }
   }
 
-  private List<List<String>> allSimplePaths() {
+  private List<List<String>> allSimplePaths(List<JsonSchema> descendents) {
     Set<List<String>> simplePaths = descendents.stream().map(s -> s.simplePath()).collect(Collectors.toSet());
     LogInfo.logs("Got %d distinct simple paths", simplePaths.size());
 
@@ -143,98 +134,33 @@ public class VegaResources {
     }
   }
 
-
-  private void processVegaTemplates() {
-    LogInfo.begin_track("processVegaTemplates");
-    templates = new ArrayList<>();
-    templatesMap = new HashMap<String,String>();
-    for (String path : opts.vegaSpecifications) {
-      File file = new File(path);
-      if (file.isFile() && file.getName().endsWith(".json"))
-        load(file);
-      else {
-        for (final File fileEntry : file.listFiles()) {
-          if (fileEntry.getName().endsWith(".json")) {
-            load(fileEntry);
-          }
-        }
-      }
-    }
-
-    List<String> allPaths = new ArrayList<>();
-    List<Pair<List<String>, JsonNode>> allPathValues = new ArrayList<>();
-
-    for (String json : templates) {
-      allPathValues.addAll(JsonUtils.allPathValues(JsonUtils.toJsonNode(Json.readMapHard(json))));
-    }
-
-    {
-      typeToValues = new HashMap<>();
-      PrintWriter writer = IOUtils.openOutHard(savePath.toString());
-      for (Pair<List<String>, JsonNode> pathValue: allPathValues) {
-        List<String> path = pathValue.getFirst();
-        JsonNode value = pathValue.getSecond();
-        try {
-          for (JsonSchema schema: vegaSchema.schemas(path)) {
-            String type = schema.schemaType();
-            if (type.equals("null") || type.equals("number") || type.equals("string")
-                || type.endsWith(".string") || type.equals("boolean") || type.equals("array")) continue;
-            MapUtils.addToList(typeToValues, type, new JsonValue(value).withSchemaType(type));
-            writer.println( schema.schemaType() + "\t" + path + "\t" + value);
-          }
-        } catch (RuntimeException ex) {
-          LogInfo.logs("VegaResource %s %s", path, ex);
-          ex.printStackTrace();
-        }
-      }
-
-      // put in a few values for very general types
-      MapUtils.addToList(typeToValues, "boolean", new JsonValue(true).withSchemaType("boolean"));
-      MapUtils.addToList(typeToValues, "boolean", new JsonValue(false).withSchemaType("boolean"));
-      // MapUtils.addToList(typeToValues, "number", new JsonValue(0).withSchemaType("number"));
-      // temporarily removing 0 based on Meghas experience on data collection
-      MapUtils.addToList(typeToValues, "number", new JsonValue(10).withSchemaType("number"));
-      MapUtils.addToList(typeToValues, "number", new JsonValue(100).withSchemaType("number"));
-      MapUtils.addToList(typeToValues, "string", new JsonValue("hello").withSchemaType("string"));
-
-      Json.prettyWriteValueHard(new File(savePath.toString()+".json"),
-          typeToValues.entrySet().stream().map(e -> {
-            return Lists.newArrayList(e.getKey(),
-                e.getValue().stream().map(jv -> jv.getJsonNode()).collect(Collectors.toList()));
-          }).collect(Collectors.toList()) );
-      writer.close();
-    }
-
-    LogInfo.logs("got %d paths, %d unique", allPaths.size(), Sets.newHashSet(allPaths).size());
-    LogInfo.end_track();
-  }
-
-  private void load(File path) {
-    LogInfo.logs("Reading example template from %s", path);
-    String text = String.join("\n", IOUtils.readLinesHard(path.getAbsolutePath()));
-    templates.add(text);
-    templatesMap.put(path.getPath(), text);
-  }
-
   public static List<JsonValue> getValues(List<String> path) {
     List<JsonSchema> schemas = vegaSchema.schemas(path);
     List<JsonValue> values = new ArrayList<>();
     for (JsonSchema schema : schemas) {
       String type = schema.schemaType();
-      if (!type.equals(JsonSchema.NOTYPE) && typeToValues.containsKey(type))
-        values.addAll(typeToValues.get(schema.schemaType()));
+      if (opts.verbose > 0)
+        LogInfo.logs("getValues %s %s", type, path.toString());
+      if (type.equals(JsonSchema.NOTYPE))
+        return values;
+      else if (type.endsWith("enum")) {
+        for (String v : schema.enums())
+          values.add(new JsonValue(v).withSchemaType(type));
+      } else if (type.equals("boolean")) {
+        values.add(new JsonValue(true).withSchemaType("boolean"));
+        values.add(new JsonValue(false).withSchemaType("boolean"));
+      } else if (type.equals("number")) {
+        values.add(new JsonValue(ThreadLocalRandom.current().nextInt(0, 100)).withSchemaType("number"));
+        values.add(new JsonValue(0.1 * ThreadLocalRandom.current().nextInt(1, 10)).withSchemaType("number"));
+      } else if (type.equals("string")) {
+        values.add(new JsonValue("X").withSchemaType("string"));
+      }
     }
-    // LogInfo.logs("VegaResources.getValues %s %s", path, values);
     return values;
   }
 
   public static Set<String> getEnumTypes(String value) {
     if (enumValueToTypes.containsKey(value)) return enumValueToTypes.get(value);
-    return null;
-  }
-
-  public static Set<List<String>> getEnumPaths(String value) {
-    if (enumValueToPaths.containsKey(value)) return enumValueToPaths.get(value);
     return null;
   }
 
@@ -246,4 +172,3 @@ public class VegaResources {
     return initialTemplates;
   }
 }
-


### PR DESCRIPTION
Usage:
```
./plot/run @mode=plot -printall -maxexamples train:0 +tags init-plot -beamsize 500
```
This adds the `init-plot` portion of the grammar. In the interface, select an initial plot and submit a query. New initial plots should also show up as additional candidates.

There is no way to toggle the `init-plot` dynamically right now.

TODO:

- [ ] Add more constraints to prune out stupid plots
- [ ] Add a way to toggle the `init-plot` section of the grammar