### PR TITLE
Merge init plot

### DIFF
--- a/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
+++ b/src/edu/stanford/nlp/sempre/interactive/JsonInitFn.java
@@ -342,6 +342,8 @@ public class JsonInitFn extends SemanticFn {
 
     private boolean check(String mark, List<Formula> channelDefs) {
       List<String> channelNames = new ArrayList<>();
+      // Disallow mark = "text" for now
+      if ("text".equals(mark)) return false;
       // Some channels only go with certain marks
       for (Formula c : channelDefs) {
         ChannelDefFormula channelDef = (ChannelDefFormula) c;

--- a/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaExecutor.java
@@ -113,10 +113,11 @@ public class VegaExecutor extends Executor {
         Formula pathf = f.args.get(1);
         Value value = ((ValueFormula) f.args.get(2)).value;
         String jsonPath = Formulas.getString(pathf);
-        ObjectNode objNode = (ObjectNode) jsonContext.getJsonNode();
+        ObjectNode objNode = (ObjectNode) jsonContext.cloneJsonNode();
         JsonUtils.setPathValue(objNode, jsonPath, ((JsonValue)value).getJsonNode());
         result = objNode;
       } else if (id.equals("init")) {
+        // read the formula
         JsonNode mark = ((JsonValue) ((ValueFormula) f.args.get(1)).value).getJsonNode();
         ActionFormula channelDefs = ((ActionFormula) f.args.get(2));
         assert channelDefs.mode == ActionFormula.Mode.sequential;
@@ -127,12 +128,13 @@ public class VegaExecutor extends Executor {
           formula = (ValueFormula<?>) ((ActionFormula) channelDef).args.get(2);
           encoding.set(channelKey, ((JsonValue) formula.value).getJsonNode());
         }
-        ObjectNode objNode = (ObjectNode) jsonContext.getJsonNode();
+        // Create the nodes
+        ObjectNode objNode = (ObjectNode) jsonContext.cloneJsonNode();
         objNode.put("$schema", "https://vega.github.io/schema/vega-lite/v2.json");
         objNode.put("mark", mark);
         objNode.put("encoding", encoding);
         if (opts.verbose >= 1)
-          System.out.println("YAY " + f + " ==> " + objNode.toString());
+          System.out.println("INIT " + f + " ==> " + objNode.toString());
         result = objNode;
       } else {
         throw new RuntimeException("VegaExecutor: formula not implemented: " + f);

--- a/src/edu/stanford/nlp/sempre/interactive/VegaJsonContextValue.java
+++ b/src/edu/stanford/nlp/sempre/interactive/VegaJsonContextValue.java
@@ -39,9 +39,16 @@ public class VegaJsonContextValue extends ContextValue {
   }
 
   /**
-   * Get a fresh copy of the whole JSON.
+   * Get the whole JSON.
    */
   public JsonNode getJsonNode() {
+    return jsonNode;
+  }
+
+  /**
+   * Get a fresh copy of the whole JSON.
+   */
+  public JsonNode cloneJsonNode() {
     return jsonNode.deepCopy();
   }
 


### PR DESCRIPTION
Addressed #36, #37, and #38 
- Executing an init formulas now modifies the current context (if exists)
- Added canonical utterances such as "create bar plot with a encoded as x; sum of b encoded as y"
- Added a few more constraints